### PR TITLE
Update Container Registry Source Options

### DIFF
--- a/.github/workflows/bicep.yml
+++ b/.github/workflows/bicep.yml
@@ -4,9 +4,9 @@ name: Bicep Template Build and Test
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: main
+    branches: [main]
   pull_request:
-    branches: main
+    branches: [main]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/ARM/azuredeploy.json
+++ b/ARM/azuredeploy.json
@@ -14,13 +14,30 @@
         "aciContainerGroupName": {
             "type": "String"
         },
+        "containerRegistry": {
+            "type": "string",
+            "defaultValue": "DockerHub",
+            "allowedValues": [
+                "DockerHub",
+                "ACR"
+            ],
+            "metadata": {
+                "description": "Selecting DockerHub will pull the Tailscale image from hub.docker.com/r/cocallaw/tailscale-sr."
+            }
+        },
         "tailscaleImageRepository": {
             "defaultValue": "myacr.azurecr.io/tailscale",
-            "type": "String"
+            "type": "String",
+            "metadata": {
+                "description": "If DockerHub is selcted as the Container Registry, leave as default value or empty"
+            }
         },
         "tailscaleImageTag": {
             "defaultValue": "latest",
-            "type": "String"
+            "type": "String",
+            "metadata": {
+                "description": "If DockerHub is selcted as the Container Registry, leave as default value or empty"
+            }
         },
         "tailscaleHoasname": {
             "defaultValue": "tailscale",
@@ -33,15 +50,33 @@
             "type": "securestring"
         },
         "tailscaleRegistryUsername": {
+            "defaultValue": "",
             "type": "String"
         },
         "tailscaleRegistryPassword": {
+            "defaultValue": "",
             "type": "secureString"
+
         }
     },
     "variables": {
-        "aci_image": "[concat(parameters('tailscaleImageRepository'),':',parameters('tailscaleImageTag'))]",
-        "tailscale_image_server": "[first(split(parameters('tailscaleImageRepository'),'/'))]"
+        "dh_image": "cocallaw/tailscale-sr:latest",
+        "acr_image": "[concat(parameters('tailscaleImageRepository'),':',parameters('tailscaleImageTag'))]",
+        "tailscale_image_server": "[first(split(parameters('tailscaleImageRepository'),'/'))]",
+        "registry_refrence": "[variables('registry_list')[parameters('containerRegistry')]]",
+        "registry_list": {
+            "DockerHub": [],
+            "ACR": {
+                "server": "[variables('tailscale_image_server')]",
+                "username": "[parameters('tailscaleRegistryUsername')]",
+                "password": "[parameters('tailscaleRegistryPassword')]"
+            }
+        },
+        "image_refrence": "[variables('image_list')[parameters('containerRegistry')]]",
+        "image_list": {
+            "DockerHub": "[variables('dh_image')]",
+            "ACR": "[variables('acr_image')]"
+        }
     },
     "resources": [
         {
@@ -61,7 +96,7 @@
                     {
                         "name": "tailscaleaci",
                         "properties": {
-                            "image": "[variables('aci_image')]",
+                            "image": "[variables('image_refrence')]",
                             "command": [],
                             "ports": [
                                 {
@@ -100,13 +135,7 @@
                     }
                 ],
                 "initContainers": [],
-                "imageRegistryCredentials": [
-                    {
-                        "server": "[variables('tailscale_image_server')]",
-                        "username": "[parameters('tailscaleRegistryUsername')]",
-                        "password": "[parameters('tailscaleRegistryPassword')]"
-                    }
-                ],
+                "imageRegistryCredentials": "[variables('registry_refrence')]",
                 "restartPolicy": "Always",
                 "ipAddress": {
                     "ports": [

--- a/ARM/azuredeploy.parameters.json
+++ b/ARM/azuredeploy.parameters.json
@@ -14,6 +14,9 @@
         "aciContainerGroupName": {
             "value": "mycontainergroup" 
         },
+        "containerRegistry": {
+            "value": "DockerHub"
+        },
         "tailscaleImageRepository": {
             "value": "myacr.azurecr.io/tailscale"
         },

--- a/README.md
+++ b/README.md
@@ -6,14 +6,18 @@ These Bicep & ARM templates deploy a Tailscale [subnet router][1] as an [Azure C
     <img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true"/> 
 </a>
 
+## Deployment 
+When deploying the ARM or Bicep templates, the value of the `containerRegistry` parameter will determine where the deployment pulls the container image from. 
+- If `DockerHub` is selected, the image will be pulled from [cocallaw/tailscale-sr on Docker Hub][3], the parameters `tailscaleImageRepository` and `tailscaleImageRepository` are not used and can be left to their default values or null.
+- If `ACR` is selected, the image will be pulled from Azure Container Registry using the values of the `tailscaleImageRepository` and `tailscaleImageRepository` parameters.
 ## Docker Container
 The `docker/Dockerfile` file extends the `tailscale/tailscale`
-[image][3] with an entrypoint script that starts the Tailscale daemon and runs
-`tailscale up` using an [auth key][4] and the relevant advertised [CIDR block][5].
+[image][4] with an entrypoint script that starts the Tailscale daemon and runs
+`tailscale up` using an [auth key][5] and the relevant advertised [CIDR block][6].
 
-The Docker container must be built and pushed to an ACR repository so that it can be referenced during deployment.
+The Docker container must be built and pushed to an ACR if the parameter `containerRegistry` is set to `ACR` so that it can be referenced during deployment. If the parameter `containerRegistry` is set to `DockerHub`, the container does not need to be built as it will be pulled from Docker Hub.
 
-### Build locally with Docker and [push image to ACR][6]
+### Build locally with Docker and [push image to ACR][7]
 ```bash
 docker build \
   --tag tailscale-subnet-router:v1 \
@@ -28,7 +32,7 @@ docker build \
   .
 ```
 
-### Build remotely using [Azure Container Registry Tasks][7] with Azure CLI
+### Build remotely using [Azure Container Registry Tasks][8] with Azure CLI
 ```bash
 ACR_NAME=<registry-name>
 az acr build --registry $ACR_NAME --image tailscale:v1 .
@@ -39,7 +43,7 @@ az acr build --registry $ACR_NAME --build-arg TAILSCALE_TAG=v1.29.18 --image tai
 ```
 
 ## Subnet Delegation 
-To assist with the deployment of the ACI container group in the Azure VNet, the subnet being used should be [delegated][8] to the `Microsoft.ContainerInstance/containerGroups`.
+To assist with the deployment of the ACI container group in the Azure VNet, the subnet being used should be [delegated][9] to the `Microsoft.ContainerInstance/containerGroups`.
 ```bash
 # Update the subnet with a delegation for Microsoft.ContainerInstance/containerGroups
 az network vnet subnet update \
@@ -57,13 +61,13 @@ az network vnet subnet update \
 ```  
 
 ## Notes
-- The Tailscale state (`/var/lib/tailscale`) is stored in a [Azure File Share][9] in a Storage Account so that the subnet router only needs to be [authorized][10] once.
+- The Tailscale state (`/var/lib/tailscale`) is stored in a [Azure File Share][10] in a Storage Account so that the subnet router only needs to be [authorized][11] once.
 
 ## Improvements Needed
 ### Container Registry Authentication
 Currently the templates only support using a username and password to authenticate to the ACR repository, and the server URL is derived from the ACR repository name.
 - Validation testing needed for use with Docker Hub
-- Add Option to use [anonymous pull][11] with ACR
+- Add Option to use [anonymous pull][12] with ACR
 - Investigate using a service principal to authenticate to the ACR repository
 
 ### Container Size Selection
@@ -73,12 +77,13 @@ When the Tailscale container is deployed, the size is set to 1 CPU core and 1 Gi
 
 [1]: https://tailscale.com/kb/1019/subnets/
 [2]: https://docs.microsoft.com/azure/container-instances/container-instances-overview
-[3]: https://hub.docker.com/r/tailscale/tailscale
-[4]: https://tailscale.com/kb/1085/auth-keys/
-[5]: https://tailscale.com/kb/1019/subnets/
-[6]: https://docs.microsoft.com/azure/container-registry/container-registry-get-started-docker-cli?tabs=azure-cli
-[7]: https://docs.microsoft.com/azure/container-registry/container-registry-tutorial-quick-task
-[8]: https://docs.microsoft.com/azure/virtual-network/subnet-delegation-overview
-[9]: https://docs.microsoft.com/azure/storage/files/storage-files-introduction
-[10]: https://tailscale.com/kb/1099/device-authorization/
-[11]: https://docs.microsoft.com/azure/container-registry/anonymous-pull-access
+[3]: https://hub.docker.com/r/cocallaw/tailscale-sr
+[4]: https://hub.docker.com/r/tailscale/tailscale
+[5]: https://tailscale.com/kb/1085/auth-keys/
+[6]: https://tailscale.com/kb/1019/subnets/
+[7]: https://docs.microsoft.com/azure/container-registry/container-registry-get-started-docker-cli?tabs=azure-cli
+[8]: https://docs.microsoft.com/azure/container-registry/container-registry-tutorial-quick-task
+[9]: https://docs.microsoft.com/azure/virtual-network/subnet-delegation-overview
+[10]: https://docs.microsoft.com/azure/storage/files/storage-files-introduction
+[11]: https://tailscale.com/kb/1099/device-authorization/
+[12]: https://docs.microsoft.com/azure/container-registry/anonymous-pull-access

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,9 +4,10 @@ The `docker/Dockerfile` file extends the `tailscale/tailscale`
 [image][1] with an entrypoint script that starts the Tailscale daemon and runs
 `tailscale up` using an [auth key][2] and the relevant advertised [CIDR block][3].
 
-The Docker container must be built and pushed to an ACR repository so that it can be referenced during deployment.
+When deploying the ARM or Bicep templates, the value of the `containerRegistry` parameter will determine where the deployment pulls the container image from. - If `DockerHub` is selected, the image will be pulled from [cocallaw/tailscale-sr on Docker Hub][4] . 
+- If `ACR` is selected, the image will be pulled from Azure Container Registry using the values of the `tailscaleImageRepository` and `tailscaleImageRepository` parameter.
 
-### Build locally with Docker and [push image to ACR][4]
+### Build locally with Docker and [push image to ACR][5]
 ```bash
 docker build \
   --tag tailscale-subnet-router:v1 \
@@ -21,7 +22,7 @@ docker build \
   .
 ```
 
-### Build remotely using [Azure Container Registry Tasks][5] with Azure CLI
+### Build remotely using [Azure Container Registry Tasks][6] with Azure CLI
 ```bash
 ACR_NAME=<registry-name>
 az acr build --registry $ACR_NAME --image tailscale:v1 .
@@ -34,5 +35,6 @@ az acr build --registry $ACR_NAME --build-arg TAILSCALE_TAG=v1.29.18 --image tai
 [1]: https://hub.docker.com/r/tailscale/tailscale
 [2]: https://tailscale.com/kb/1085/auth-keys/
 [3]: https://tailscale.com/kb/1019/subnets/
-[4]: https://docs.microsoft.com/azure/container-registry/container-registry-get-started-docker-cli?tabs=azure-cli
-[5]: https://docs.microsoft.com/azure/container-registry/container-registry-tutorial-quick-task
+[4]: https://hub.docker.com/r/cocallaw/tailscale-sr
+[5]: https://docs.microsoft.com/azure/container-registry/container-registry-get-started-docker-cli?tabs=azure-cli
+[6]: https://docs.microsoft.com/azure/container-registry/container-registry-tutorial-quick-task


### PR DESCRIPTION
- Added Docker Hub as a source for the Tailscale Subnet Router Container
- Added Parameter to select either ACR or DockerHub as the container source
- General Readme updates for clarification