### PR TITLE
Add option to select ACI container size

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -34,6 +34,7 @@ jobs:
   armtemplate:
     needs: changes
     if: ${{ needs.changes.outputs.armtemplate == 'true' }}
+    name: ARM Template Validation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/bicep.yml
+++ b/.github/workflows/bicep.yml
@@ -33,7 +33,7 @@ jobs:
   build_and_test:
     needs: changes
     if: ${{ needs.changes.outputs.biceptemplate == 'true' }}
-    name: Secure Lab Bicep Build and Test
+    name: Bicep Build and Test
 
     runs-on: ubuntu-latest
 

--- a/ARM/azuredeploy.json
+++ b/ARM/azuredeploy.json
@@ -14,6 +14,28 @@
         "aciContainerGroupName": {
             "type": "String"
         },
+        "tailscaleHoasname": {
+            "defaultValue": "tailscale",
+            "type": "String"
+        },
+        "tailscaleAdvertiseRoutes": {
+            "type": "String"
+        },
+        "tailscaleAuthKey": {
+            "type": "securestring"
+        },
+        "containerSize": {
+            "type": "String",
+            "defaultValue": "Small",
+            "allowedValues": [
+                "Small",
+                "Medium",
+                "Large"
+            ],
+            "metadata": {
+                "description": "Size of the ACI container to deploy"
+            }
+        },
         "containerRegistry": {
             "type": "string",
             "defaultValue": "DockerHub",
@@ -39,23 +61,19 @@
                 "description": "If DockerHub is selcted as the Container Registry, leave as default value or empty"
             }
         },
-        "tailscaleHoasname": {
-            "defaultValue": "tailscale",
-            "type": "String"
-        },
-        "tailscaleAdvertiseRoutes": {
-            "type": "String"
-        },
-        "tailscaleAuthKey": {
-            "type": "securestring"
-        },
         "tailscaleRegistryUsername": {
             "defaultValue": "",
-            "type": "String"
+            "type": "String",
+            "metadata": {
+                "description": "If DockerHub is selcted as the Container Registry, leave as default value or empty"
+            }
         },
         "tailscaleRegistryPassword": {
             "defaultValue": "",
-            "type": "secureString"
+            "type": "secureString",
+            "metadata": {
+                "description": "If DockerHub is selcted as the Container Registry, leave as default value or empty"
+            }
 
         }
     },
@@ -76,6 +94,21 @@
         "image_list": {
             "DockerHub": "[variables('dh_image')]",
             "ACR": "[variables('acr_image')]"
+        },
+        "containersize_refrence": "[variables('containersize_list')[parameters('containerSize')]]",
+        "containersize_list": {
+            "Small": {
+                "memoryInGB": 1,
+                "cpu": 1
+            },
+            "Medium": {
+                "memoryInGB": 2,
+                "cpu": 2
+            },
+            "Large": {
+                "memoryInGB": 4,
+                "cpu": 4
+            }
         }
     },
     "resources": [
@@ -119,10 +152,7 @@
                                 }
                             ],
                             "resources": {
-                                "requests": {
-                                    "memoryInGB": 1,
-                                    "cpu": 1
-                                }
+                                "requests": "[variables('containersize_refrence')]"
                             },
                             "volumeMounts": [
                                 {

--- a/ARM/azuredeploy.parameters.json
+++ b/ARM/azuredeploy.parameters.json
@@ -14,15 +14,6 @@
         "aciContainerGroupName": {
             "value": "mycontainergroup" 
         },
-        "containerRegistry": {
-            "value": "DockerHub"
-        },
-        "tailscaleImageRepository": {
-            "value": "myacr.azurecr.io/tailscale"
-        },
-        "tailscaleImageTag": {
-            "value": "latest"
-        },
         "tailscaleHoasname": {
             "value": "tailscale"
         },
@@ -31,6 +22,18 @@
         },
         "tailscaleAuthKey": {
             "value": "" 
+        },
+        "containerSize": {
+            "value": "Small" 
+        },
+        "containerRegistry": {
+            "value": "DockerHub"
+        },
+        "tailscaleImageRepository": {
+            "value": "myacr.azurecr.io/tailscale"
+        },
+        "tailscaleImageTag": {
+            "value": "latest"
         },
         "tailscaleRegistryUsername": {
             "value": "" 


### PR DESCRIPTION
-Added `containerSize` Parameter
-The value of `containerSize` parameter will set the CPU/RAM for the container based on the values defined for S/M/L in variable `containersize_list`

Resolves https://github.com/cocallaw/azure-tailscale-aci-deploy/issues/2